### PR TITLE
Improve DTMF detection

### DIFF
--- a/dtmf.py
+++ b/dtmf.py
@@ -51,7 +51,7 @@ elif args.right and not args.left:
         print ("Warning: The sound is not mono and not stereo ("+str(data.shape[1])+" canals)... so the -r option was ignored.")
 
 else:
-    if len(data.shape) == 2: 
+    if len(data.shape) == 2:
         data = data.sum(axis=1) # stereo
 
 precision = args.i
@@ -88,15 +88,15 @@ try:
             plt.plot(signal)
             plt.xticks([])
             plt.yticks([])
-        
-        
+
+
         frequencies = np.fft.fftfreq(signal.size, d=1/fps)
         amplitudes = np.fft.fft(signal)
 
         # Low
         i_min = np.where(frequencies > 0)[0][0]
         i_max = np.where(frequencies > 1050)[0][0]
-        
+
         freq = frequencies[i_min:i_max]
         amp = abs(amplitudes.real[i_min:i_max])
 

--- a/dtmf.py
+++ b/dtmf.py
@@ -73,6 +73,10 @@ if verbose:
 try:
     for i in range(0, len(data)-step, step):
         signal = data[i:i+step]
+        # Since Fourier transforms work best on periodic signals, we can
+        # fake it for this slice of signal by appending a mirrored
+        # copy. This helps limit the noise in low-frequency bins.
+        signal = np.append(signal, np.flip(signal))
 
         if debug:
             plt.subplot(311)

--- a/dtmf.py
+++ b/dtmf.py
@@ -95,6 +95,8 @@ try:
             plt.plot(signal)
             plt.xticks([])
             plt.yticks([])
+            plt.subplot(313)
+            plt.title("Fourier transform")
 
 
         frequencies = np.fft.fftfreq(signal.size, d=1/fps)
@@ -118,8 +120,6 @@ try:
                 best = f
 
         if debug:
-            plt.subplot(313)
-            plt.title("Fourier transform")
             plt.plot(freq, amp)
             plt.yticks([])
             plt.annotate(str(int(lf))+"Hz", xy=(lf, max(amp)))
@@ -150,6 +150,7 @@ try:
         hf = best
 
         if debug:
+            plt.yticks([])
             if lf == 0 or hf == 0:
                 txt = "Unknown dial tone"
             else:

--- a/dtmf.py
+++ b/dtmf.py
@@ -14,8 +14,8 @@ parser.add_argument("-l", "--left", help="left channel only (if the sound is ste
 parser.add_argument("-r", "--right", help="right channel only (if the sound is stereo)", action="store_true")
 parser.add_argument("-d", "--debug", help="show graphs to debug", action="store_true")
 parser.add_argument("-t", type=int, metavar="F", help="acceptable frequency error (in hertz, 20 by default)", default=20)
-parser.add_argument("-i", type=float, metavar='T', help="process by T seconds intervals (0.04 by default)", default=0.04)
-parser.add_argument("-f", type=float, metavar="FRAC", help="process by shifting interval by 1/FRAC (3.0 by default)", default=3.0)
+parser.add_argument("-i", type=float, metavar='T', help="process by T seconds intervals (0.05 by default)", default=0.05)
+parser.add_argument("-f", type=float, metavar="FRAC", help="process by shifting interval by 1/FRAC (2.0 by default)", default=2.0)
 parser.add_argument("-s", type=float, metavar="SD", help="ignore signals less than SD above median (3.0 by default)", default=3.0)
 parser.add_argument("-m", type=float, metavar="MIN", help="ignore hf signals less than 1/MIN above lf (3.0 by default)", default=3.0)
 

--- a/dtmf.py
+++ b/dtmf.py
@@ -69,6 +69,12 @@ debug = args.debug
 verbose = args.verbose
 c = ""
 
+lfset = set()
+hfset = set()
+for key in dtmf:
+    lfset.add(key[0])
+    hfset.add(key[1])
+
 if debug:
     print("Warning:\nThe debug mode is very uncomfortable: you need to close each window to continue.\nFeel free to kill the process doing CTRL+C and then close the window.\n")
 
@@ -162,7 +168,7 @@ try:
         freq = frequencies[i_min:i_max]
         amp = abs(amplitudes.real[i_min:i_max])
 
-        [lf, lfamp] = findbest(freq, amp, args.t, 0, [697, 770, 852, 941])
+        [lf, lfamp] = findbest(freq, amp, args.t, 0, list(lfset))
 
         # High
         i_min = np.where(frequencies > 1100)[0][0]
@@ -173,7 +179,7 @@ try:
 
         minamp = lfamp // args.m;
 
-        [hf, hfamp] = findbest(freq, amp, args.t, minamp, [1209, 1336, 1477, 1633])
+        [hf, hfamp] = findbest(freq, amp, args.t, minamp, list(hfset))
 
 
         if debug:

--- a/dtmf.py
+++ b/dtmf.py
@@ -73,6 +73,23 @@ if debug:
 if verbose:
     print ("0:00 ", end='', flush=True)
 
+def findbest(freq, amp, maxdelta, freqlist):
+    maxf = freq[np.where(amp == max(amp))[0][0]]
+
+    delta = maxdelta
+    best = 0
+
+    for f in freqlist:
+        if abs(maxf-f) < delta:
+            delta = abs(maxf-f)
+            best = f
+
+    if debug:
+        plt.plot(freq, amp)
+        plt.annotate(str(int(maxf))+"Hz", xy=(maxf, max(amp)))
+
+    return best
+
 try:
     for i in range(0, len(data)-window, step):
         signal = data[i:i+window]
@@ -109,22 +126,7 @@ try:
         freq = frequencies[i_min:i_max]
         amp = abs(amplitudes.real[i_min:i_max])
 
-        lf = freq[np.where(amp == max(amp))[0][0]]
-
-        delta = args.t
-        best = 0
-
-        for f in [697, 770, 852, 941]:
-            if abs(lf-f) < delta:
-                delta = abs(lf-f)
-                best = f
-
-        if debug:
-            plt.plot(freq, amp)
-            plt.yticks([])
-            plt.annotate(str(int(lf))+"Hz", xy=(lf, max(amp)))
-
-        lf = best
+        lf = findbest(freq, amp, args.t, [697, 770, 852, 941])
 
         # High
         i_min = np.where(frequencies > 1100)[0][0]
@@ -133,21 +135,7 @@ try:
         freq = frequencies[i_min:i_max]
         amp = abs(amplitudes.real[i_min:i_max])
 
-        hf = freq[np.where(amp == max(amp))[0][0]]
-
-        delta = args.t
-        best = 0
-
-        for f in [1209, 1336, 1477, 1633]:
-            if abs(hf-f) < delta:
-                delta = abs(hf-f)
-                best = f
-
-        if debug:
-            plt.plot(freq, amp)
-            plt.annotate(str(int(hf))+"Hz", xy=(hf, max(amp)))
-
-        hf = best
+        hf = findbest(freq, amp, args.t, [1209, 1336, 1477, 1633])
 
         if debug:
             plt.yticks([])


### PR DESCRIPTION
This PR contains a few improvements to detecting DTMF signals:

- Make FFT inputs look more like periodic inputs, to reduce low-frequency noise
- Slide input window by less than 100% (default to 50%)
- Consider more frequencies than just highest amplitude when matching
- Don't consider high frequencies to be a match if they are too weak (default to minimum of 1/3 of low frequency amplitude)

It also has some minor code cleanups.